### PR TITLE
Provide a way to use pip to install external packages

### DIFF
--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -43,6 +43,12 @@ namespace Python.Included
                 try
                 {
                     ZipFile.ExtractToDirectory(zip, zip.Replace(".zip", ""));
+                    
+                    // allow pip on embedded python installation
+                    // see https://github.com/pypa/pip/issues/4207#issuecomment-281236055
+                    var pth = Path.Combine(EmbeddedPythonHome, PYTHON_VERSION + "._pth");
+                    string lines = File.ReadAllText(pth);
+                    lines = lines.Replace("#import site", "import site");
                 }
                 catch (Exception e)
                 {

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -155,7 +155,7 @@ namespace Python.Included
             if (!IsPipInstalled())
                 try { InstallPip(); } catch { throw new FileNotFoundException("pip is not installed"); }
 
-            if (IsModuleInstalled(module_name))
+            if (IsModuleInstalled(module_name) && !force)
                 return;
 
             string pipPath = Path.Combine(EmbeddedPythonHome, "Scripts", "pip");

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -155,6 +155,9 @@ namespace Python.Included
             if (!IsPipInstalled())
                 try { InstallPip(); } catch { throw new FileNotFoundException("pip is not installed"); }
 
+            if (IsModuleInstalled(module_name))
+                return;
+
             string pipPath = Path.Combine(EmbeddedPythonHome, "Scripts", "pip");
             string forceInstall = force ? " --force-reinstall" : "";
             RunCommand($"{pipPath} install {module_name}{forceInstall}");

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -3,16 +3,28 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Python.Runtime;
 
 namespace Python.Included
 {
-    public class Installer
+    public static class Installer
     {
         public const string EMBEDDED_PYTHON = "python-3.7.3-embed-amd64";
         public const string PYTHON_VERSION = "python37";
-        public async Task SetupPython(bool force = false)
+
+        public static string EmbeddedPythonHome
+        {
+            get
+            {
+                var appdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                var install_dir = Path.Combine(appdata, EMBEDDED_PYTHON);
+                return install_dir;
+            }
+        }
+
+        public static async Task SetupPython(bool force = false)
         {
             if (!PythonEnv.DeployEmbeddedPython)
                 return;
@@ -23,7 +35,7 @@ namespace Python.Included
                 return;
             await Task.Run(() =>
             {
-                var assembly = this.GetType().Assembly;
+                var assembly = typeof(Installer).Assembly;
                 var appdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
                 var zip = Path.Combine(appdata, $"{EMBEDDED_PYTHON}.zip");
                 var resource_name = EMBEDDED_PYTHON;
@@ -37,7 +49,7 @@ namespace Python.Included
             });
         }
 
-        private void CopyEmbeddedResourceToFile(Assembly assembly, string resourceName, string filePath, bool force = false)
+        private static void CopyEmbeddedResourceToFile(Assembly assembly, string resourceName, string filePath, bool force = false)
         {
             if (force || !File.Exists(filePath))
             {
@@ -52,6 +64,11 @@ namespace Python.Included
             }
         }
 
+        public static string GetResourceKey(Assembly assembly, string embedded_file)
+        {
+            return assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains(embedded_file));
+        }
+
         /// <summary>
         /// Install a python library (.whl file) in the embedded python installation of Python.Included
         /// </summary>
@@ -59,7 +76,7 @@ namespace Python.Included
         /// <param name="resource_name">Name of the embedded wheel file i.e. "numpy-1.16.3-cp37-cp37m-win_amd64.whl"</param>
         /// <param name="force"></param>
         /// <returns></returns>
-        public async Task InstallWheel(Assembly assembly, string resource_name, bool force = false)
+        public static async Task InstallWheel(Assembly assembly, string resource_name, bool force = false)
         {
             var key = GetResourceKey(assembly, resource_name);
             if (string.IsNullOrWhiteSpace(key))
@@ -90,19 +107,96 @@ namespace Python.Included
             });
         }
 
-        public string EmbeddedPythonHome
+        /// <summary>
+        /// Uses the local python-embedded pip module to install a python library (.whl file) in the embedded python installation of Python.Included
+        /// </summary>
+        /// <param name="assembly">The assembly containing the embedded wheel</param>
+        /// <param name="resource_name">Name of the embedded wheel file i.e. "numpy-1.16.3-cp37-cp37m-win_amd64.whl"</param>
+        /// <param name="force"></param>
+        /// <returns></returns>
+        public static void PipInstallWheel(Assembly assembly, string resource_name, bool force = false)
         {
-            get
-            {
-                var appdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-                var install_dir = Path.Combine(appdata, EMBEDDED_PYTHON);
-                return install_dir;
-            }
+            string key = GetResourceKey(assembly, resource_name);
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentException($"The resource '{resource_name}' was not found in assembly '{assembly.FullName}'");
+            string module_name = resource_name.Split('-').FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(module_name))
+                throw new ArgumentException($"The resource name '{resource_name}' did not contain a valid module name");
+            string libDir = Path.Combine(EmbeddedPythonHome, "Lib");
+            if (!Directory.Exists(libDir))
+                Directory.CreateDirectory(libDir);
+            string module_path = Path.Combine(libDir, module_name);
+            if (!force && Directory.Exists(module_path))
+                return;
+
+            string wheelPath = Path.Combine(libDir, key);
+            string pipPath = Path.Combine(EmbeddedPythonHome, "Scripts", "pip");
+
+            CopyEmbeddedResourceToFile(assembly, key, wheelPath, force);
+
+            RunCommand($"{pipPath} install {wheelPath}");
         }
 
-        public string GetResourceKey(Assembly assembly, string embedded_file)
+        public static void PipInstallModule(string module_name, bool force = false)
         {
-            return assembly.GetManifestResourceNames().FirstOrDefault(x => x.Contains(embedded_file));
+            if (!IsPipInstalled())
+                throw new FileNotFoundException("pip is not installed");
+
+            string pipPath = Path.Combine(EmbeddedPythonHome, "Scripts", "pip");
+
+            string forceInstall = force ? " --force-reinstall" : "";
+            RunCommand($"{pipPath} install {module_name}{forceInstall}");
+        }
+
+        public static void InstallPip()
+        {
+            string libDir = Path.Combine(EmbeddedPythonHome, "Lib");
+            RunCommand($"cd {libDir} && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py");
+            RunCommand($"cd {EmbeddedPythonHome} && python.exe Lib\\get-pip.py");
+        }
+
+        public static bool IsPythonInstalled()
+        {
+            var appdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string pythonHome = Path.Combine(appdata, Installer.EMBEDDED_PYTHON);
+            string libDir = Path.Combine(pythonHome, "Lib");
+            bool isInstalled = true;
+            isInstalled &= Directory.Exists(pythonHome);
+            isInstalled &= File.Exists(Path.Combine(pythonHome, "python.exe"));
+            return isInstalled;
+        }
+
+        public static bool IsPipInstalled()
+        {
+            return File.Exists(Path.Combine(EmbeddedPythonHome, "Scripts", "pip.exe"));
+        }
+
+        public static bool IsModuleInstalled(string module)
+        {
+            if (!IsPythonInstalled())
+                return false;
+
+            string moduleDir = Path.Combine(EmbeddedPythonHome, "Lib", module);
+            return Directory.Exists(moduleDir) && File.Exists(Path.Combine(moduleDir, "__init__.py"));
+        }
+
+        private static void RunCommand(string command, bool runInBackground = false)
+        {
+            System.Diagnostics.Process process = new System.Diagnostics.Process();
+            System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo();
+            if (runInBackground)
+                startInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
+            startInfo.FileName = "cmd.exe";
+            string commandMode = runInBackground ? "/C" : "/K";
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                startInfo.FileName = "/bin/bash";
+                commandMode = commandMode.Replace('/', '-');
+            }
+            startInfo.Arguments = $"{commandMode} {command}";
+            process.StartInfo = startInfo;
+            process.Start();
+            process.WaitForExit();
         }
     }
 }

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -28,7 +28,7 @@ namespace Python.Included
         {
             if (!PythonEnv.DeployEmbeddedPython)
                 return;
-            if (Runtime.Runtime.pyversion!="3.7")
+            if (Runtime.Runtime.pyversion != "3.7")
                 throw new InvalidOperationException("You must compile Python.Runtime with PYTHON37 flag! Runtime version: " + Runtime.Runtime.pyversion);
             Environment.SetEnvironmentVariable("PATH", $"{EmbeddedPythonHome};" + Environment.GetEnvironmentVariable("PATH"));
             if (!force && Directory.Exists(EmbeddedPythonHome) && File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"))) // python seems installed, so exit
@@ -40,10 +40,12 @@ namespace Python.Included
                 var zip = Path.Combine(appdata, $"{EMBEDDED_PYTHON}.zip");
                 var resource_name = EMBEDDED_PYTHON;
                 CopyEmbeddedResourceToFile(assembly, resource_name, zip, force);
-                try {
+                try
+                {
                     ZipFile.ExtractToDirectory(zip, zip.Replace(".zip", ""));
                 }
-                catch (Exception e) {
+                catch (Exception e)
+                {
                     // todo log
                 }
             });
@@ -94,10 +96,12 @@ namespace Python.Included
             await Task.Run(() =>
             {
                 CopyEmbeddedResourceToFile(assembly, key, wheelPath, force);
-                try {
+                try
+                {
                     ZipFile.ExtractToDirectory(wheelPath, lib);
                 }
-                catch (Exception e) {
+                catch (Exception e)
+                {
                     // todo
                 }
                 // modify _pth file
@@ -140,10 +144,9 @@ namespace Python.Included
         public static void PipInstallModule(string module_name, bool force = false)
         {
             if (!IsPipInstalled())
-                throw new FileNotFoundException("pip is not installed");
+                try { InstallPip(); } catch { throw new FileNotFoundException("pip is not installed"); }
 
             string pipPath = Path.Combine(EmbeddedPythonHome, "Scripts", "pip");
-
             string forceInstall = force ? " --force-reinstall" : "";
             RunCommand($"{pipPath} install {module_name}{forceInstall}");
         }

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -144,6 +144,9 @@ namespace Python.Included
 
             CopyEmbeddedResourceToFile(assembly, key, wheelPath, force);
 
+            if (!IsPipInstalled())
+                try { InstallPip(); } catch { throw new FileNotFoundException("pip is not installed"); }
+
             RunCommand($"{pipPath} install {wheelPath}");
         }
 

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -172,13 +172,8 @@ namespace Python.Included
 
         public static bool IsPythonInstalled()
         {
-            var appdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            string pythonHome = Path.Combine(appdata, Installer.EMBEDDED_PYTHON);
-            string libDir = Path.Combine(pythonHome, "Lib");
-            bool isInstalled = true;
-            isInstalled &= Directory.Exists(pythonHome);
-            isInstalled &= File.Exists(Path.Combine(pythonHome, "python.exe"));
-            return isInstalled;
+            return File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"));
+
         }
 
         public static bool IsPipInstalled()

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -180,7 +180,7 @@ namespace Python.Included
             return Directory.Exists(moduleDir) && File.Exists(Path.Combine(moduleDir, "__init__.py"));
         }
 
-        private static void RunCommand(string command, bool runInBackground = false)
+        public static void RunCommand(string command, bool runInBackground = false)
         {
             System.Diagnostics.Process process = new System.Diagnostics.Process();
             System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo();
@@ -188,10 +188,10 @@ namespace Python.Included
                 startInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
             startInfo.FileName = "cmd.exe";
             string commandMode = runInBackground ? "/C" : "/K";
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 startInfo.FileName = "/bin/bash";
-                commandMode = commandMode.Replace('/', '-');
+                commandMode = "-c";
             }
             startInfo.Arguments = $"{commandMode} {command}";
             process.StartInfo = startInfo;


### PR DESCRIPTION
Many times installing a whl file by its own does not install dependencies. In general, it does not provide all the functionalities we are use to with `conda` and `pip`.

The pr contains 3 changes:
- New methods to deal with pip
- Installer is a `static` class
- The `python37._pth` file in the embedded-python resource has been modified to accommodate the use of pip as described in https://github.com/pypa/pip/issues/4207#issuecomment-281236055