### PR TITLE
Use quotation marks to support all possible install paths

### DIFF
--- a/Python.Deployment/DownloadInstallationSource.cs
+++ b/Python.Deployment/DownloadInstallationSource.cs
@@ -53,7 +53,7 @@ namespace Python.Deployment
                 var zipFile = Path.Combine(destinationDirectory, GetPythonZipFileName());
                 if (!Force && File.Exists(zipFile))
                     return zipFile;
-                await RunCommand($"curl {DownloadUrl} -o {zipFile}", CancellationToken.None);
+                await RunCommand($"curl {DownloadUrl} -o \"{zipFile}\"", CancellationToken.None);
                 return zipFile;
             }
 


### PR DESCRIPTION
I have tried to address following issue:
fixes #31

This should allow paths with spaces in them - but i have not tested it yet.