### PR TITLE
Using httpclient for downloads to remove reliance on curl

### DIFF
--- a/Python.Deployment/DownloadInstallationSource.cs
+++ b/Python.Deployment/DownloadInstallationSource.cs
@@ -23,13 +23,9 @@ SOFTWARE.
  */
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -53,8 +49,19 @@ namespace Python.Deployment
                 var zipFile = Path.Combine(destinationDirectory, GetPythonZipFileName());
                 if (!Force && File.Exists(zipFile))
                     return zipFile;
-                await RunCommand($"curl {DownloadUrl} -o \"{zipFile}\"", CancellationToken.None);
-                return zipFile;
+
+                try
+                {
+                    Log("Downloading source...");
+                    await Downloader.Download(DownloadUrl, zipFile);
+                    return zipFile;
+                }
+                catch (Exception)
+                {
+                    Log("There was a problem downloading the source.");
+                    return String.Empty;
+                }
+
             }
 
             public override string GetPythonZipFileName()

--- a/Python.Deployment/DownloadInstallationSource.cs
+++ b/Python.Deployment/DownloadInstallationSource.cs
@@ -57,10 +57,10 @@ namespace Python.Deployment
                     Log("Done!");
                     return zipFile;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    Log("There was a problem downloading the source.");
-                    return String.Empty;
+                    Log($"There was a problem downloading the source: {ex.Message}");
+                    return string.Empty;
                 }
 
             }

--- a/Python.Deployment/DownloadInstallationSource.cs
+++ b/Python.Deployment/DownloadInstallationSource.cs
@@ -53,7 +53,8 @@ namespace Python.Deployment
                 try
                 {
                     Log("Downloading source...");
-                    await Downloader.Download(DownloadUrl, zipFile);
+                    await Downloader.Download(DownloadUrl, zipFile, progress => Log($"{progress:F2}%"));
+                    Log("Done!");
                     return zipFile;
                 }
                 catch (Exception)

--- a/Python.Deployment/Downloader.cs
+++ b/Python.Deployment/Downloader.cs
@@ -1,5 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Python.Deployment
@@ -8,12 +10,55 @@ namespace Python.Deployment
     {
         private static readonly HttpClient httpClient = new HttpClient();
 
-        public static async Task Download(string downloadUrl, string outputFileName)
+        public static async Task Download(
+            string downloadUrl,
+            string outputFilePath,
+            Action<float> progress = null,
+            CancellationToken token = default)
         {
-            Stream responseStream = await httpClient.GetStreamAsync(downloadUrl);
-            using (FileStream fileStream = new FileStream(outputFileName, FileMode.Create))
+            using (FileStream fileStream = new FileStream(outputFilePath, FileMode.Create))
             {
-                await responseStream.CopyToAsync(fileStream);
+                await httpClient.DownloadWithProgressAsync(downloadUrl, fileStream, progress, token);
+            }
+        }
+
+
+    }
+
+    public static class HttpClientExtension
+    {
+        public static async Task DownloadWithProgressAsync(
+            this HttpClient client,
+            string requestUri,
+            Stream destination,
+            Action<float> progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            using (var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead))
+            {
+                var contentLength = response.Content.Headers.ContentLength;
+
+                using (var download = await response.Content.ReadAsStreamAsync())
+                {
+                    int bufferSize = 81920;
+
+                    if (progress == null || !contentLength.HasValue)
+                    {
+                        await download.CopyToAsync(destination, bufferSize, cancellationToken);
+                        return;
+                    }
+
+                    var buffer = new byte[bufferSize];
+                    long totalBytesRead = 0;
+                    int bytesRead;
+                    while ((bytesRead = await download.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) != 0)
+                    {
+                        await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+                        totalBytesRead += bytesRead;
+                        var progressPercentage = ((float)totalBytesRead / contentLength.Value) * 100;
+                        progress.Invoke(progressPercentage);
+                    }
+                }
             }
         }
     }

--- a/Python.Deployment/Downloader.cs
+++ b/Python.Deployment/Downloader.cs
@@ -13,7 +13,7 @@ namespace Python.Deployment
             Stream responseStream = await httpClient.GetStreamAsync(downloadUrl);
             using (FileStream fileStream = new FileStream(outputFileName, FileMode.Create))
             {
-                responseStream.CopyTo(fileStream);
+                await responseStream.CopyToAsync(fileStream);
             }
         }
     }

--- a/Python.Deployment/Downloader.cs
+++ b/Python.Deployment/Downloader.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Python.Deployment
+{
+    public static class Downloader
+    {
+        private static readonly HttpClient httpClient = new HttpClient();
+
+        public static async Task Download(string downloadUrl, string outputFileName)
+        {
+            Stream responseStream = await httpClient.GetStreamAsync(downloadUrl);
+            using (FileStream fileStream = new FileStream(outputFileName, FileMode.Create))
+            {
+                await responseStream.CopyToAsync(fileStream);
+            }
+        }
+    }
+}

--- a/Python.Deployment/Downloader.cs
+++ b/Python.Deployment/Downloader.cs
@@ -23,7 +23,7 @@ namespace Python.Deployment
                     await httpClient.DownloadWithProgressAsync(downloadUrl, fileStream, progress, token);
                 }
             }
-            catch (OperationCanceledException)
+            catch
             {
                 if (File.Exists(outputFilePath))
                 {
@@ -45,6 +45,8 @@ namespace Python.Deployment
         {
             using (var response = await client.GetAsync(requestUri, HttpCompletionOption.ResponseHeadersRead))
             {
+                response.EnsureSuccessStatusCode();
+
                 var contentLength = response.Content.Headers.ContentLength;
 
                 using (var download = await response.Content.ReadAsStreamAsync())

--- a/Python.Deployment/Downloader.cs
+++ b/Python.Deployment/Downloader.cs
@@ -16,9 +16,20 @@ namespace Python.Deployment
             Action<float> progress = null,
             CancellationToken token = default)
         {
-            using (FileStream fileStream = new FileStream(outputFilePath, FileMode.Create))
+            try
             {
-                await httpClient.DownloadWithProgressAsync(downloadUrl, fileStream, progress, token);
+                using (FileStream fileStream = new FileStream(outputFilePath, FileMode.Create))
+                {
+                    await httpClient.DownloadWithProgressAsync(downloadUrl, fileStream, progress, token);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                if (File.Exists(outputFilePath))
+                {
+                    File.Delete(outputFilePath);
+                }
+                throw;
             }
         }
     }

--- a/Python.Deployment/Downloader.cs
+++ b/Python.Deployment/Downloader.cs
@@ -21,8 +21,6 @@ namespace Python.Deployment
                 await httpClient.DownloadWithProgressAsync(downloadUrl, fileStream, progress, token);
             }
         }
-
-
     }
 
     public static class HttpClientExtension

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -208,7 +208,7 @@ namespace Python.Deployment
                 // modify _pth file
                 var pth = Path.Combine(EmbeddedPythonHome, Source.GetPythonVersion() + "._pth");
                 if (File.Exists(pth) && !File.ReadAllLines(pth).Contains("./Lib"))
-                    File.AppendAllLines(pth, new[] {"./Lib"});
+                    File.AppendAllLines(pth, new[] { "./Lib" });
             }).ConfigureAwait(false);
         }
 
@@ -315,24 +315,27 @@ namespace Python.Deployment
         /// terminate when complete. When true, the command window must be manually closed before
         /// processing will continue.
         /// </param>
-        public static void InstallPip()
+        public static async Task InstallPip()
         {
             string libDir = Path.Combine(EmbeddedPythonHome, "Lib");
 
             if (!Directory.Exists(libDir))
                 Directory.CreateDirectory(libDir);
 
-            RunCommand($"cd {libDir} && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py");
+            string getPipUrl = @"https://bootstrap.pypa.io/get-pip.py";
+            string getPipFilePath = Path.Combine(libDir, "get-pip.py");
+            await Downloader.Download(getPipUrl, getPipFilePath);
+
             RunCommand($"cd {EmbeddedPythonHome} && python.exe Lib\\get-pip.py");
         }
 
-        public static bool TryInstallPip(bool force = false)
+        public static async Task<bool> TryInstallPip(bool force = false)
         {
             if (!IsPipInstalled() || force)
             {
                 try
                 {
-                    InstallPip();
+                    await InstallPip();
                 }
                 catch
                 {

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -331,9 +331,9 @@ namespace Python.Deployment
                 await Downloader.Download(getPipUrl, getPipFilePath, progress => Log($"{progress:F2}%"));
                 Log("Done!");
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Log("There was a problem downloading pip.");
+                Log($"There was a problem downloading pip: {ex.Message}");
                 return;
             }
 

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -324,7 +324,9 @@ namespace Python.Deployment
 
             string getPipUrl = @"https://bootstrap.pypa.io/get-pip.py";
             string getPipFilePath = Path.Combine(libDir, "get-pip.py");
-            await Downloader.Download(getPipUrl, getPipFilePath);
+            Log("Downloading Pip...");
+            await Downloader.Download(getPipUrl, getPipFilePath, progress => Log($"{progress:F2}%"));
+            Log("Done!");
 
             RunCommand($"cd {EmbeddedPythonHome} && python.exe Lib\\get-pip.py");
         }

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -23,16 +23,9 @@ SOFTWARE.
  */
 
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Python.Runtime;
 
 namespace Python.Included
 {
@@ -132,7 +125,7 @@ namespace Python.Included
         /// <param name="resource_name">Name of the embedded wheel file i.e. "numpy-1.16.3-cp37-cp37m-win_amd64.whl"</param>
         /// <param name="force"></param>
         /// <returns></returns>
-        public static void PipInstallWheel(Assembly assembly, string resource_name, bool force = false)
+        public static async Task PipInstallWheel(Assembly assembly, string resource_name, bool force = false)
         {
             try
             {
@@ -140,7 +133,7 @@ namespace Python.Included
                 Python.Deployment.Installer.Source = GetInstallationSource();
                 Python.Deployment.Installer.PythonDirectoryName = InstallDirectory;
                 Python.Deployment.Installer.InstallPath = InstallPath;
-                Python.Deployment.Installer.PipInstallWheel(assembly, resource_name, force);
+                await Python.Deployment.Installer.PipInstallWheel(assembly, resource_name, force);
             }
             finally
             {
@@ -153,7 +146,7 @@ namespace Python.Included
         /// </summary>
         /// <param name="module_name">The module/package to install </param>
         /// <param name="force">When true, reinstall the packages even if it is already up-to-date.</param>
-        public static void PipInstallModule(string module_name, string version = "", bool force = false)
+        public static async Task PipInstallModule(string module_name, string version = "", bool force = false)
         {
             try
             {
@@ -161,7 +154,7 @@ namespace Python.Included
                 Python.Deployment.Installer.Source = GetInstallationSource();
                 Python.Deployment.Installer.PythonDirectoryName = InstallDirectory;
                 Python.Deployment.Installer.InstallPath = InstallPath;
-                Python.Deployment.Installer.PipInstallModule(module_name, version, force);
+                await Python.Deployment.Installer.PipInstallModule(module_name, version, force);
             }
             finally
             {
@@ -175,7 +168,7 @@ namespace Python.Included
         /// <remarks>
         /// Creates the lib folder under <see cref="EmbeddedPythonHome"/> if it does not exist.
         /// </remarks>
-        public static void InstallPip()
+        public static async Task InstallPip()
         {
             try
             {
@@ -183,7 +176,7 @@ namespace Python.Included
                 Python.Deployment.Installer.Source = GetInstallationSource();
                 Python.Deployment.Installer.PythonDirectoryName = InstallDirectory;
                 Python.Deployment.Installer.InstallPath = InstallPath;
-                Python.Deployment.Installer.InstallPip();
+                await Python.Deployment.Installer.InstallPip();
             }
             finally
             {

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -184,13 +184,13 @@ namespace Python.Included
             }
         }
 
-        public static bool TryInstallPip(bool force = false)
+        public static async Task<bool> TryInstallPip(bool force = false)
         {
             if (!IsPipInstalled() || force)
             {
                 try
                 {
-                    InstallPip();
+                    await InstallPip();
                 }
                 catch
                 {

--- a/Python.Installer.Tests/DownloaderTests.cs
+++ b/Python.Installer.Tests/DownloaderTests.cs
@@ -1,0 +1,67 @@
+﻿using NUnit.Framework;
+using Python.Deployment;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Python.Tests
+{
+    /// <summary>
+    /// These tests are not strictly unit tests. Because of the difficulties of unit testing
+    /// with HttpClient in a static class, these tests rely on using the HttpClient class and actually 
+    /// downloading the resource at <see cref="TestResources.DownloadUrl"/>. These tests will fail if 
+    /// there are network errors or if that resource is otherwise no longer available.
+    /// </summary>
+    public class DownloaderTests
+    {
+        [Test]
+        public void DownloaderCanCancel()
+        {
+            var outputFile = new TemporaryFile(TestResources.DownloadFilename);
+            var cts = new CancellationTokenSource();
+
+            var downloadTask = Downloader.Download(
+                TestResources.DownloadUrl,
+                outputFile,
+                null,
+                cts.Token);
+
+            cts.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(async () => await Task.WhenAll(downloadTask));
+            Assert.IsFalse(File.Exists(outputFile));
+
+            outputFile.Dispose();
+        }
+
+        [Test]
+        public async Task DownloaderDownloadsFile()
+        {
+            var outputFile = new TemporaryFile(TestResources.DownloadFilename);
+
+            await Downloader.Download(TestResources.DownloadUrl, outputFile);
+
+            Assert.IsTrue(File.Exists(outputFile));
+
+            outputFile.Dispose();
+        }
+
+        [Test]
+        public async Task DownloaderReportsProgress()
+        {
+            float percentProgress = 0;
+            void OnPercentageProgess(float percentage)
+            {
+                percentProgress = percentage;
+            }
+
+            await Downloader.Download(
+                TestResources.DownloadUrl,
+                TestResources.DownloadFilename,
+                OnPercentageProgess);
+
+            Assert.AreNotEqual(0, percentProgress);
+        }
+    }
+}

--- a/Python.Installer.Tests/DownloaderTests.cs
+++ b/Python.Installer.Tests/DownloaderTests.cs
@@ -61,7 +61,7 @@ namespace Python.Tests
                 TestResources.DownloadFilename,
                 OnPercentageProgess);
 
-            Assert.AreNotEqual(0, percentProgress);
+            Assert.AreEqual(100, percentProgress);
         }
     }
 }

--- a/Python.Installer.Tests/TemporaryFile.cs
+++ b/Python.Installer.Tests/TemporaryFile.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.IO;
+
+namespace Python.Tests
+{
+    public class TemporaryFile : IDisposable
+    {
+        private readonly string path;
+
+        public TemporaryFile(string filename)
+        {
+            path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}-{filename}");
+        }
+
+        public static implicit operator string(TemporaryFile temporaryFile) => temporaryFile.path;
+
+        public void Dispose()
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+}

--- a/Python.Installer.Tests/TestResources.cs
+++ b/Python.Installer.Tests/TestResources.cs
@@ -1,0 +1,8 @@
+﻿namespace Python.Tests
+{
+    internal static class TestResources
+    {
+        public static readonly string DownloadUrl = @"https://github.com/henon/Python.Included/raw/master/Python.Included/Resources/python_included_nuget.png";
+        public static readonly string DownloadFilename = @"python_included_nuget.png";
+    }
+}

--- a/Python.Installer.Tests/TestResources.cs
+++ b/Python.Installer.Tests/TestResources.cs
@@ -2,7 +2,8 @@
 {
     internal static class TestResources
     {
-        public static readonly string DownloadUrl = @"https://github.com/henon/Python.Included/raw/master/Python.Included/Resources/python_included_nuget.png";
+        public static readonly string DownloadValidUrl = @"https://github.com/henon/Python.Included/raw/master/Python.Included/Resources/python_included_nuget.png";
+        public static readonly string DownloadNotFoundUrl = @"https://github.com/henon/Python.Included/raw/master/Python.Included/Resources/python_included_nuget.pn";
         public static readonly string DownloadFilename = @"python_included_nuget.png";
     }
 }

--- a/examples/Python.Included.Example.NetFramework/Program.cs
+++ b/examples/Python.Included.Example.NetFramework/Program.cs
@@ -24,10 +24,10 @@ namespace Python.Included.Example.NetFramework
             await Installer.SetupPython();
 
             // install pip3 for package installation
-            Installer.TryInstallPip();
+            await Installer.TryInstallPip();
 
             // download and install Spacy from the internet
-            Installer.PipInstallModule("spacy");
+            await Installer.PipInstallModule("spacy");
 
             // ok, now use pythonnet from that installation
             PythonEngine.Initialize();


### PR DESCRIPTION
I'm not sure if you had a specific reason to rely on curl, but I wanted to remove the dependency so I implemented a downloader that uses httpclient for the downloading and that can report progress on the download.  Unfortunately, doing so results in changing the signature of a number of public methods to async.  That seems to be a breaking change.  In any event, obviously feel free to accept if you find it useful or reject. 