### PR TITLE
Python.Include using pre-installed Python in Linux

### DIFF
--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -76,8 +76,12 @@ namespace Python.Deployment
         public static async Task SetupPython(bool force = false)
         {
             Environment.SetEnvironmentVariable("PATH", $"{EmbeddedPythonHome};" + Environment.GetEnvironmentVariable("PATH"));
-            if (!force && Directory.Exists(EmbeddedPythonHome) && File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"))) // python seems installed, so exit
-                return;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                if (!force && Directory.Exists(EmbeddedPythonHome) && File.Exists(Path.Combine(EmbeddedPythonHome, "python"))) // python seems installed, so exit
+                    return;
+            else
+                if (!force && Directory.Exists(EmbeddedPythonHome) && File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"))) // python seems installed, so exit
+                    return;
             var zip = await Source.RetrievePythonZip(InstallPath);
             if (string.IsNullOrWhiteSpace(zip))
             {
@@ -296,7 +300,11 @@ namespace Python.Deployment
             if (IsModuleInstalled(module_name) && !force)
                 return;
 
-            string pipPath = Path.Combine(EmbeddedPythonHome, "Scripts", "pip");
+            string pipPath;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                pipPath = Path.Combine(EmbeddedPythonHome, "pip");
+            else
+                pipPath = Path.Combine(EmbeddedPythonHome, "Scripts", "pip.exe");
             string forceInstall = force ? " --force-reinstall" : "";
             if (version.Length > 0)
                 version = $"=={version}";
@@ -359,13 +367,19 @@ namespace Python.Deployment
 
         public static bool IsPythonInstalled()
         {
-            return File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return File.Exists(Path.Combine(EmbeddedPythonHome, "python"));
+            else
+                return File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"));
 
         }
 
         public static bool IsPipInstalled()
         {
-            return File.Exists(Path.Combine(EmbeddedPythonHome, "Scripts", "pip.exe"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return File.Exists(Path.Combine(EmbeddedPythonHome, "pip"));
+            else
+                return File.Exists(Path.Combine(EmbeddedPythonHome, "Scripts", "pip.exe"));
         }
 
         public static bool IsModuleInstalled(string module)

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -456,8 +456,8 @@ namespace Python.Deployment
                     catch (Exception) { /* ignore */ }
                 });
                 // The documentation for Process.StandardOutput says to read before you wait otherwise you can deadlock!
-                string output = process.StandardOutput.ReadToEnd();
-                Log(output);
+                //string output = process.StandardOutput.ReadToEnd();
+                //Log(output);
                 await Task.Run(() => { process.WaitForExit(); }, token);
                 if (process.ExitCode != 0)
                     Log(" => exit code " + process.ExitCode);

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -415,7 +415,7 @@ namespace Python.Deployment
                 {
                     // Unix/Linux/macOS specific command execution
                     filename = "/bin/bash";
-                    args = $"-c {command}";
+                    args = $@"-c ""{command}""";
                 }
                 else
                 {

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -26,6 +26,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace Python.Included
 {
@@ -204,12 +205,18 @@ namespace Python.Included
 
         public static bool IsPythonInstalled()
         {
-            return File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return File.Exists(Path.Combine(EmbeddedPythonHome, "python"));
+            else
+                return File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"));
         }
 
         public static bool IsPipInstalled()
         {
-            return File.Exists(Path.Combine(EmbeddedPythonHome, "Scripts", "pip.exe"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return File.Exists(Path.Combine(EmbeddedPythonHome, "pip"));
+            else
+                return File.Exists(Path.Combine(EmbeddedPythonHome, "Scripts", "pip.exe"));
         }
 
         public static bool IsModuleInstalled(string module)


### PR DESCRIPTION
Allows Python.Included to work with Linux which usually has Python pre-installed.

This came out due to the discussion in #52, but I honestly don't know if the OP of that question will find this useful. I use this as a test bed for an internal project since my dev system is Linux only.


Sample usage:
https://github.com/167rgc911/Python.Included/blob/ppl_tests/examples/Python.Included.Linux/Program.cs
https://github.com/167rgc911/Python.Included/blob/ppl_tests/examples/Python.Deployment.Linux/Program.cs

**Limitations:**
This does not deploy any embedded Python versions as those are mostly Windows builds only.

Not really tested in Windows (but most of the touched code has "protection" and gets called in case of a Linux environment only).

Even with Python pre-installed in most Linux distributions, the installation directories are typically not writable by normal users. Using Virtual environments (venv) are a good option as the module installation code will not need modifications and you will have less chance of thrashing the system installed Python.
