### PR TITLE
Upgrade to Python 3.13

### DIFF
--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -31,7 +31,7 @@ namespace Python.Included
 {
     public static class Installer
     {
-        public const string PYTHON_VERSION = "python311";
+        public const string PYTHON_VERSION = "python313";
 
         /// <summary>
         /// Path to install python. If needed, set before calling SetupPython().
@@ -43,7 +43,7 @@ namespace Python.Included
         /// Name of the python directory. If needed, set before calling SetupPython().
         /// Defaults to python-3.7.3-embed-amd64
         /// </summary>
-        public static string InstallDirectory { get; set; } = "python-3.11.0-embed-amd64";
+        public static string InstallDirectory { get; set; } = "python-3.13.0-embed-amd64";
 
         /// <summary>
         /// The full path to the Python directory. Customize this by setting InstallPath and InstallDirectory
@@ -66,7 +66,7 @@ namespace Python.Included
                 return;
                     
             if (Runtime.Runtime.PythonDLL == null)
-                Runtime.Runtime.PythonDLL = "python311.dll"; // <-- note: since pythonnet v3.0.1 this can not be set multiple times!
+                Runtime.Runtime.PythonDLL = "python313.dll"; // <-- note: since pythonnet v3.0.1 this can not be set multiple times!
             
             try
             {
@@ -87,7 +87,7 @@ namespace Python.Included
             return new Python.Deployment.Installer.EmbeddedResourceInstallationSource()
             {
                 Assembly = typeof(PythonEnv).Assembly,
-                ResourceName = "python-3.11.0-embed-amd64.zip",
+                ResourceName = "python-3.13.0-embed-amd64.zip",
             };
         }
 

--- a/Python.Included/Python.Included.csproj
+++ b/Python.Included/Python.Included.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.11.6</Version>
+    <Version>3.13.0</Version>
     <Authors>Meinrad Recheis and Python Software Foundation</Authors>
     <Description>Python.Included is an automatic deployment mechanism for .NET packages which depend on the embedded Python distribution. This allows libraries depending on Python and/or Python packages to be deployed via Nuget without having to worry about any local Python installations.</Description>
     <PackageLicenseUrl></PackageLicenseUrl>
@@ -20,11 +20,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Resources\python-3.11.0-embed-amd64.zip" />
+    <None Remove="Resources\python-3.13.0-embed-amd64.zip" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\python-3.11.0-embed-amd64.zip" />
+    <EmbeddedResource Include="Resources\python-3.13.0-embed-amd64.zip" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi @henon,

I’m Ivo from the Autodesk Dynamo team. We’re updating our default Python engine to PythonNet3 and need Python 3.13 embedded support.

I've proposed some changes to update to Python 3.13: 
- Replaced the embedded zip with Resources/python-3.13.0-embed-amd64.zip.
- Updated Installer.cs constants to python313 (PYTHON_VERSION, InstallDirectory, python313.dll, resource name).
- Updated Python.Included.csproj to embed the 3.13 zip and set the package version to 3.13.0.

Tested:
- Built locally on Windows x64.
- Small console smoke test using Python.NET:

```
Embedded Python home: ...\python-3.13.0-embed-amd64
PythonDLL: ...\python313.dll
sys.version = 3.13.0
math.sqrt(9) = 3.0
```
Some notes:
- I left AssemblyVersion unchanged (to avoid binding churn) and bumped FileVersion to 3.13.0.0.
- If you prefer AssemblyVersion to match the embedded CPython version, I can bump that too.

Closes #66.

Thanks!
Ivo