### PR TITLE
Add progress callback

### DIFF
--- a/Python.Deployment/DownloadInstallationSource.cs
+++ b/Python.Deployment/DownloadInstallationSource.cs
@@ -44,7 +44,7 @@ namespace Python.Deployment
             /// </summary>
             public string DownloadUrl { get; set; }
 
-            public override async Task<string> RetrievePythonZip(string destinationDirectory)
+            public override async Task<string> RetrievePythonZip(string destinationDirectory, Action<float> progress = null, CancellationToken token = default)
             {
                 var zipFile = Path.Combine(destinationDirectory, GetPythonZipFileName());
                 if (!Force && File.Exists(zipFile))
@@ -53,7 +53,7 @@ namespace Python.Deployment
                 try
                 {
                     Log("Downloading source...");
-                    await Downloader.Download(DownloadUrl, zipFile, progress => Log($"{progress:F2}%")).ConfigureAwait(false);
+                    await Downloader.Download(DownloadUrl, zipFile, p => { Log($"{p:F2}%"); progress?.Invoke(p); }, token).ConfigureAwait(false);
                     Log("Done!");
                     return zipFile;
                 }

--- a/Python.Deployment/EmbeddedResourceInstallationSource.cs
+++ b/Python.Deployment/EmbeddedResourceInstallationSource.cs
@@ -28,6 +28,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Python.Deployment
@@ -51,7 +52,7 @@ namespace Python.Deployment
             /// </summary>
             public string ResourceName { get; set; }
 
-            public override Task<string> RetrievePythonZip(string destinationDirectory)
+            public override Task<string> RetrievePythonZip(string destinationDirectory, Action<float> progress = null, CancellationToken token = default)
             {
                 var filePath = Path.Combine(destinationDirectory, ResourceName);
                 if (!Force && File.Exists(filePath))

--- a/Python.Deployment/InstallationSource.cs
+++ b/Python.Deployment/InstallationSource.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Python.Deployment
@@ -46,7 +47,7 @@ namespace Python.Deployment
             /// </summary>
             /// <param name="destinationDirectory">The directory location where the retrieved zip file should be placed</param>
             /// <returns></returns>
-            public abstract Task<string> RetrievePythonZip(string destinationDirectory);
+            public abstract Task<string> RetrievePythonZip(string destinationDirectory, Action<float> progress = null, CancellationToken token = default);
 
             /// <summary>
             /// If true, retrieve the python file again even if it already exists at the destination path

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -297,7 +297,6 @@ namespace Python.Deployment
             if (IsModuleInstalled(module_name) && !force)
                 return;
 
-            string pythonPath = Path.Combine(EmbeddedPythonHome, "python.exe");
             string forceInstall = force ? " --force-reinstall" : "";
             if (version.Length > 0)
                 version = $"=={version}";
@@ -305,8 +304,7 @@ namespace Python.Deployment
             await RunPipCommand(
                 $"-u -m pip install \"{module_name}{version}\" --no-cache-dir --progress-bar raw{forceInstall}",
                 token,
-                progress,
-                pythonPath).ConfigureAwait(false);
+                progress).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -453,39 +451,20 @@ namespace Python.Deployment
             }
         }
 
-        private static async Task RunPipCommand(string command, CancellationToken token, Action<float> progress = null, string filename = null)
+        private static async Task RunPipCommand(string pipArguments, CancellationToken token, Action<float> progress = null)
         {
             Process process = new Process();
             try
             {
-                string args;
+                var pythonPath = Path.Combine(EmbeddedPythonHome, "python.exe");
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    if (string.IsNullOrEmpty(filename))
-                        filename = "/bin/bash";
-                    args = $"-c \"{command}\"";
-                }
-                else
-                {
-                    if (string.IsNullOrEmpty(filename))
-                    {
-                        filename = "cmd.exe";
-                        args = $"/C \"{command}\"";
-                    }
-                    else
-                    {
-                        args = command;
-                    }
-                }
-
-                Log($"> {filename} {args}");
+                Log($"> \"{pythonPath}\" {pipArguments}");
 
                 var startInfo = new ProcessStartInfo
                 {
-                    FileName = filename,
+                    FileName = pythonPath,
                     WorkingDirectory = EmbeddedPythonHome,
-                    Arguments = args,
+                    Arguments = pipArguments,
                     CreateNoWindow = true,
                     UseShellExecute = false,
                     RedirectStandardError = true,
@@ -535,7 +514,7 @@ namespace Python.Deployment
             }
             catch (Exception e)
             {
-                Log($"RunPipCommand: Error with command: '{command}'\r\n{e.Message}");
+                Log($"RunPipCommand: Error with arguments: '{pipArguments}'\r\n{e.Message}");
             }
             finally
             {

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -302,7 +302,7 @@ namespace Python.Deployment
             if (version.Length > 0)
                 version = $"=={version}";
 
-            await RunCommand($"python -u -m \"{pipPath}\" install \"{module_name}{version}\" --no-cache-dir --progress-bar on {forceInstall}", token, progress).ConfigureAwait(false);
+            await RunCommand($"python -u \"{pipPath}\" install \"{module_name}{version}\" --no-cache-dir --progress-bar on{forceInstall}", token, progress).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -388,6 +388,7 @@ namespace Python.Deployment
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
+                    // Unix/Linux/macOS specific command execution
                     if (string.IsNullOrEmpty(filename))
                         filename = "/bin/bash";
                     args = $"-c \"{command}\"";
@@ -396,13 +397,12 @@ namespace Python.Deployment
                 {
                     if (string.IsNullOrEmpty(filename))
                     {
-                        // 没有指定 filename，走 cmd.exe
+                        // Windows specific command execution
                         filename = "cmd.exe";
                         args = $"/C \"{command}\"";
                     }
                     else
                     {
-                        // 直接启动指定程序，不加 /C
                         args = command;
                     }
                 }
@@ -422,15 +422,18 @@ namespace Python.Deployment
                     WindowStyle = ProcessWindowStyle.Hidden,
                 };
 
-                // 关键：禁用 Python 和 pip 的输出缓冲
+                // Key: Disable output buffering for Python and pip
                 startInfo.Environment["PYTHONUNBUFFERED"] = "1";
                 startInfo.Environment["PYTHONIOENCODING"] = "utf-8";
-                startInfo.Environment["PIP_NO_COLOR"] = "1";        // 去掉颜色转义字符干扰
-                startInfo.Environment["COLUMNS"] = "200";            // 避免 pip 截断进度行
+                startInfo.Environment["PIP_NO_COLOR"] = "1";
+                startInfo.Environment["COLUMNS"] = "200";
 
                 process.StartInfo = startInfo;
                 process.Start();
-
+                // Note: see https://github.com/henon/Python.Included/issues/55#issuecomment-1634750418
+                // as to why the following lines are commented out
+                //process.BeginOutputReadLine();
+                //process.BeginErrorReadLine();
                 token.Register(() =>
                 {
                     try { if (!process.HasExited) process.Kill(); }
@@ -439,13 +442,13 @@ namespace Python.Deployment
 
                 var readStdOut = ReadStreamAsync(process.StandardOutput, line =>
                 {
-                    Log($"[ERR] '{line}'"); // 看 stderr 收到什么
+                    Log($"[ERR] '{line}'");
                     ParsePipProgress(line, progress);
                 }, token);
 
                 var readStdErr = ReadStreamAsync(process.StandardError, line =>
                 {
-                    Log($"[ERR] '{line}'"); // 看 stderr 收到什么
+                    Log($"[ERR] '{line}'");
                     Console.WriteLine(line);
                 }, token);
 
@@ -459,7 +462,7 @@ namespace Python.Deployment
             }
             catch (OperationCanceledException)
             {
-                Log("RunCommand: 已取消");
+                Log("RunCommand: Cancelled");
             }
             catch (Exception e)
             {
@@ -496,7 +499,6 @@ namespace Python.Deployment
                 }
             }
 
-            // 读完剩余内容
             if (sb.Length > 0)
                 callback(sb.ToString());
         }
@@ -505,7 +507,6 @@ namespace Python.Deployment
         {
             if (progress == null) return;
 
-            // 匹配 "Progress 已下载 of 总大小"
             var match = System.Text.RegularExpressions.Regex.Match(
                 line, @"Progress (\d+) of (\d+)"
             );

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -302,8 +302,11 @@ namespace Python.Deployment
             if (version.Length > 0)
                 version = $"=={version}";
 
-            await RunCommand(
-                $"-u -m pip install \"{module_name}{version}\" --no-cache-dir --progress-bar raw{forceInstall}", token, progress, pythonPath).ConfigureAwait(false);
+            await RunPipCommand(
+                $"-u -m pip install \"{module_name}{version}\" --no-cache-dir --progress-bar raw{forceInstall}",
+                token,
+                progress,
+                pythonPath).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -339,8 +342,7 @@ namespace Python.Deployment
                 return;
             }
 
-
-            await RunCommand($"cd \"{EmbeddedPythonHome}\" && python.exe Lib\\get-pip.py", token, progress).ConfigureAwait(false);
+            await RunCommand($"cd \"{EmbeddedPythonHome}\" && python.exe Lib\\get-pip.py", token).ConfigureAwait(false);
         }
 
         public static async Task<bool> TryInstallPip(Action<float> progress = null, CancellationToken token = default, bool force = false)
@@ -379,7 +381,79 @@ namespace Python.Deployment
             return Directory.Exists(moduleDir) && File.Exists(Path.Combine(moduleDir, "__init__.py"));
         }
 
-        public static async Task RunCommand(string command, CancellationToken token, Action<float> progress = null, string filename = null)
+        public static async Task RunCommand(string command, CancellationToken token)
+        {
+            Process process = new Process();
+            try
+            {
+                string args = null;
+                string filename = null;
+                ProcessStartInfo startInfo = new ProcessStartInfo();
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    // Unix/Linux/macOS specific command execution
+                    filename = "/bin/bash";
+                    args = $"-c \"{command} \"";
+                }
+                else
+                {
+                    // Windows specific command execution
+                    filename = "cmd.exe";
+                    args = $"/C \"{command}\"";
+                }
+                Log($"> {filename} {args}");
+                startInfo = new ProcessStartInfo
+                {
+                    FileName = filename,
+                    WorkingDirectory = EmbeddedPythonHome,
+                    Arguments = args,
+
+                    // If the UseShellExecute property is true, the CreateNoWindow property value is ignored and a new window is created.
+                    // .NET Core does not support creating windows directly on Unix/Linux/macOS and the property is ignored.
+
+                    CreateNoWindow = true,
+                    UseShellExecute = false, // necessary for stdout redirection
+                    RedirectStandardError = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                };
+                process.StartInfo = startInfo;
+                process.Start();
+                // Note: see https://github.com/henon/Python.Included/issues/55#issuecomment-1634750418
+                // as to why the following lines are commented out
+                //process.BeginOutputReadLine();
+                //process.BeginErrorReadLine();
+                token.Register(() =>
+                {
+                    try
+                    {
+                        if (!process.HasExited)
+                            process.Kill();
+                    }
+                    catch (Exception) { /* ignore */ }
+                });
+                // The documentation for Process.StandardOutput says to read before you wait otherwise you can deadlock!
+                string output = process.StandardOutput.ReadToEnd();
+                Log(output);
+                await Task.Run(() => { process.WaitForExit(); }, token).ConfigureAwait(false);
+                if (process.ExitCode != 0)
+                {
+                    Log(process.StandardError.ReadToEnd());
+                    Log(" => exit code " + process.ExitCode);
+                }
+            }
+            catch (Exception e)
+            {
+                Log($"RunCommand: Error with command: '{command}'\r\n{e.Message}");
+            }
+            finally
+            {
+                process?.Dispose();
+            }
+        }
+
+        private static async Task RunPipCommand(string command, CancellationToken token, Action<float> progress = null, string filename = null)
         {
             Process process = new Process();
             try
@@ -388,7 +462,6 @@ namespace Python.Deployment
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    // Unix/Linux/macOS specific command execution
                     if (string.IsNullOrEmpty(filename))
                         filename = "/bin/bash";
                     args = $"-c \"{command}\"";
@@ -397,7 +470,6 @@ namespace Python.Deployment
                 {
                     if (string.IsNullOrEmpty(filename))
                     {
-                        // Windows specific command execution
                         filename = "cmd.exe";
                         args = $"/C \"{command}\"";
                     }
@@ -414,19 +486,15 @@ namespace Python.Deployment
                     FileName = filename,
                     WorkingDirectory = EmbeddedPythonHome,
                     Arguments = args,
-
-                    // If the UseShellExecute property is true, the CreateNoWindow property value is ignored and a new window is created.
-                    // .NET Core does not support creating windows directly on Unix/Linux/macOS and the property is ignored.
-
                     CreateNoWindow = true,
-                    UseShellExecute = false,// necessary for stdout redirection
+                    UseShellExecute = false,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     WindowStyle = ProcessWindowStyle.Hidden,
                 };
 
-                // Key: Disable output buffering for Python and pip
+                // pip-specific output/format settings
                 startInfo.Environment["PYTHONUNBUFFERED"] = "1";
                 startInfo.Environment["PYTHONIOENCODING"] = "utf-8";
                 startInfo.Environment["PIP_NO_COLOR"] = "1";
@@ -434,10 +502,7 @@ namespace Python.Deployment
 
                 process.StartInfo = startInfo;
                 process.Start();
-                // Note: see https://github.com/henon/Python.Included/issues/55#issuecomment-1634750418
-                // as to why the following lines are commented out
-                //process.BeginOutputReadLine();
-                //process.BeginErrorReadLine();
+
                 token.Register(() =>
                 {
                     try { if (!process.HasExited) process.Kill(); }
@@ -446,7 +511,7 @@ namespace Python.Deployment
 
                 var readStdOut = ReadStreamAsync(process.StandardOutput, line =>
                 {
-                    Log($"[ERR] '{line}'");
+                    Log($"[OUT] '{line}'");
                     ParsePipProgress(line, progress);
                 }, token);
 
@@ -466,11 +531,11 @@ namespace Python.Deployment
             }
             catch (OperationCanceledException)
             {
-                Log("RunCommand: Cancelled");
+                Log("RunPipCommand: Cancelled");
             }
             catch (Exception e)
             {
-                Log($"RunCommand: Error with command: '{command}'\r\n{e.Message}");
+                Log($"RunPipCommand: Error with command: '{command}'\r\n{e.Message}");
             }
             finally
             {
@@ -526,6 +591,7 @@ namespace Python.Deployment
                 }
             }
         }
+
         private static bool AreAllFilesAlreadyPresent(ZipArchive zip, string lib)
         {
             var allFilesAllReadyPresent = true;

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -414,8 +414,12 @@ namespace Python.Deployment
                     FileName = filename,
                     WorkingDirectory = EmbeddedPythonHome,
                     Arguments = args,
+
+                    // If the UseShellExecute property is true, the CreateNoWindow property value is ignored and a new window is created.
+                    // .NET Core does not support creating windows directly on Unix/Linux/macOS and the property is ignored.
+
                     CreateNoWindow = true,
-                    UseShellExecute = false,
+                    UseShellExecute = false,// necessary for stdout redirection
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -297,12 +297,13 @@ namespace Python.Deployment
             if (IsModuleInstalled(module_name) && !force)
                 return;
 
-            string pipPath = Path.Combine(EmbeddedPythonHome, "Scripts", "pip");
+            string pythonPath = Path.Combine(EmbeddedPythonHome, "python.exe");
             string forceInstall = force ? " --force-reinstall" : "";
             if (version.Length > 0)
                 version = $"=={version}";
 
-            await RunCommand($"python -u \"{pipPath}\" install \"{module_name}{version}\" --no-cache-dir --progress-bar on{forceInstall}", token, progress).ConfigureAwait(false);
+            await RunCommand(
+                $"-u -m pip install \"{module_name}{version}\" --no-cache-dir --progress-bar raw{forceInstall}", token, progress, pythonPath).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -378,22 +379,32 @@ namespace Python.Deployment
             return Directory.Exists(moduleDir) && File.Exists(Path.Combine(moduleDir, "__init__.py"));
         }
 
-        public static async Task RunCommand(string command, CancellationToken token, Action<float> progress = null)
+        public static async Task RunCommand(string command, CancellationToken token, Action<float> progress = null, string filename = null)
         {
             Process process = new Process();
             try
             {
-                string filename, args;
+                string args;
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    filename = "/bin/bash";
+                    if (string.IsNullOrEmpty(filename))
+                        filename = "/bin/bash";
                     args = $"-c \"{command}\"";
                 }
                 else
                 {
-                    filename = "cmd.exe";
-                    args = $"/C \"{command}\"";
+                    if (string.IsNullOrEmpty(filename))
+                    {
+                        // 没有指定 filename，走 cmd.exe
+                        filename = "cmd.exe";
+                        args = $"/C \"{command}\"";
+                    }
+                    else
+                    {
+                        // 直接启动指定程序，不加 /C
+                        args = command;
+                    }
                 }
 
                 Log($"> {filename} {args}");
@@ -411,6 +422,12 @@ namespace Python.Deployment
                     WindowStyle = ProcessWindowStyle.Hidden,
                 };
 
+                // 关键：禁用 Python 和 pip 的输出缓冲
+                startInfo.Environment["PYTHONUNBUFFERED"] = "1";
+                startInfo.Environment["PYTHONIOENCODING"] = "utf-8";
+                startInfo.Environment["PIP_NO_COLOR"] = "1";        // 去掉颜色转义字符干扰
+                startInfo.Environment["COLUMNS"] = "200";            // 避免 pip 截断进度行
+
                 process.StartInfo = startInfo;
                 process.Start();
 
@@ -422,13 +439,13 @@ namespace Python.Deployment
 
                 var readStdOut = ReadStreamAsync(process.StandardOutput, line =>
                 {
-                    Log(line);
+                    Log($"[ERR] '{line}'"); // 看 stderr 收到什么
                     ParsePipProgress(line, progress);
                 }, token);
 
                 var readStdErr = ReadStreamAsync(process.StandardError, line =>
                 {
-                    Log(line);
+                    Log($"[ERR] '{line}'"); // 看 stderr 收到什么
                     Console.WriteLine(line);
                 }, token);
 
@@ -454,53 +471,55 @@ namespace Python.Deployment
             }
         }
 
-        private static async Task ReadStreamAsync(
-            StreamReader reader,
-            Action<string> onLine,
-            CancellationToken token)
+        private static async Task ReadStreamAsync(StreamReader reader, Action<string> callback, CancellationToken token)
         {
-            string line;
-            while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
+            var sb = new System.Text.StringBuilder();
+            char[] buf = new char[1];
+
+            while (!reader.EndOfStream && !token.IsCancellationRequested)
             {
-                token.ThrowIfCancellationRequested();
-                onLine?.Invoke(line);
+                int read = await reader.ReadAsync(buf, 0, 1).ConfigureAwait(false);
+                if (read == 0) break;
+
+                char c = buf[0];
+                if (c == '\n' || c == '\r')
+                {
+                    if (sb.Length > 0)
+                    {
+                        callback(sb.ToString());
+                        sb.Clear();
+                    }
+                }
+                else
+                {
+                    sb.Append(c);
+                }
             }
+
+            // 读完剩余内容
+            if (sb.Length > 0)
+                callback(sb.ToString());
         }
 
         private static void ParsePipProgress(string line, Action<float> progress)
         {
             if (progress == null) return;
-            Console.WriteLine(line);
-            // pip 新版 (≥22.0): "  6.4/15.9 MB  1.2 MB/s"
-            var newPip = Regex.Match(line, @"([\d.]+)/([\d.]+)\s*(KB|MB|GB)");
-            if (newPip.Success)
+
+            // 匹配 "Progress 已下载 of 总大小"
+            var match = System.Text.RegularExpressions.Regex.Match(
+                line, @"Progress (\d+) of (\d+)"
+            );
+
+            if (match.Success)
             {
-                if (float.TryParse(newPip.Groups[1].Value, out float current) &&
-                    float.TryParse(newPip.Groups[2].Value, out float total) &&
+                if (long.TryParse(match.Groups[1].Value, out long current) &&
+                    long.TryParse(match.Groups[2].Value, out long total) &&
                     total > 0)
                 {
-                    progress.Invoke(Math.Min(current / total * 100.0f, 100.0f));
-                    return;
+                    float percent = (float)current / total * 100f;
+                    progress(Math.Min(Math.Max(percent, 0f), 99f));
                 }
             }
-
-            // pip 旧版 (<22.0): "  |████████░░░░|"
-            var oldPip = Regex.Match(line, @"\|(█+)(░*)\|");
-            if (oldPip.Success)
-            {
-                int filled = oldPip.Groups[1].Value.Length;
-                int empty = oldPip.Groups[2].Value.Length;
-                int total = filled + empty;
-                if (total > 0)
-                {
-                    progress.Invoke((float)filled / total);
-                    return;
-                }
-            }
-
-            // 开始下载时重置为 0
-            if (Regex.IsMatch(line, @"Downloading .+\.whl"))
-                progress.Invoke(0.0f);
         }
         private static bool AreAllFilesAlreadyPresent(ZipArchive zip, string lib)
         {

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -29,6 +29,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -73,12 +74,12 @@ namespace Python.Deployment
             LogMessage?.Invoke(message);
         }
 
-        public static async Task SetupPython(bool force = false)
+        public static async Task SetupPython(Action<float> progress = null, CancellationToken token = default, bool force = false)
         {
             Environment.SetEnvironmentVariable("PATH", $"{EmbeddedPythonHome};" + Environment.GetEnvironmentVariable("PATH"));
             if (!force && Directory.Exists(EmbeddedPythonHome) && File.Exists(Path.Combine(EmbeddedPythonHome, "python.exe"))) // python seems installed, so exit
                 return;
-            var zip = await Source.RetrievePythonZip(InstallPath).ConfigureAwait(false);
+            var zip = await Source.RetrievePythonZip(InstallPath, progress, token).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(zip))
             {
                 Log("SetupPython: Error obtaining zip file from installation source");
@@ -242,7 +243,7 @@ namespace Python.Deployment
 
             CopyEmbeddedResourceToFile(assembly, key, wheelPath, force);
 
-            await TryInstallPip().ConfigureAwait(false);
+            await TryInstallPip(token: token).ConfigureAwait(false);
 
             await RunCommand($"\"{pipPath}\" install \"{wheelPath}\"", token).ConfigureAwait(false);
         }
@@ -289,9 +290,9 @@ namespace Python.Deployment
         /// terminate when complete. When true, the command window must be manually closed before
         /// processing will continue.
         /// </param>
-        public static async Task PipInstallModule(string module_name, string version = "", bool force = false, CancellationToken token = default)
+        public static async Task PipInstallModule(string module_name, string version = "", bool force = false, Action<float> progress = null, CancellationToken token = default)
         {
-            await TryInstallPip().ConfigureAwait(false);
+            await TryInstallPip(progress, token, force).ConfigureAwait(false);
 
             if (IsModuleInstalled(module_name) && !force)
                 return;
@@ -301,7 +302,7 @@ namespace Python.Deployment
             if (version.Length > 0)
                 version = $"=={version}";
 
-            await RunCommand($"\"{pipPath}\" install \"{module_name}{version}\" {forceInstall}", token).ConfigureAwait(false);
+            await RunCommand($"python -u -m \"{pipPath}\" install \"{module_name}{version}\" --no-cache-dir --progress-bar on {forceInstall}", token, progress).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -315,7 +316,7 @@ namespace Python.Deployment
         /// terminate when complete. When true, the command window must be manually closed before
         /// processing will continue.
         /// </param>
-        public static async Task InstallPip(CancellationToken token = default)
+        public static async Task InstallPip(Action<float> progress = null, CancellationToken token = default)
         {
             string libDir = Path.Combine(EmbeddedPythonHome, "Lib");
 
@@ -328,7 +329,7 @@ namespace Python.Deployment
             try
             {
                 Log("Downloading Pip...");
-                await Downloader.Download(getPipUrl, getPipFilePath, progress => Log($"{progress:F2}%")).ConfigureAwait(false);
+                await Downloader.Download(getPipUrl, getPipFilePath, p => { Log($"{p:F2}%"); progress?.Invoke(p); }).ConfigureAwait(false);
                 Log("Done!");
             }
             catch (Exception ex)
@@ -338,16 +339,16 @@ namespace Python.Deployment
             }
 
 
-            await RunCommand($"cd \"{EmbeddedPythonHome}\" && python.exe Lib\\get-pip.py", token).ConfigureAwait(false);
+            await RunCommand($"cd \"{EmbeddedPythonHome}\" && python.exe Lib\\get-pip.py", token, progress).ConfigureAwait(false);
         }
 
-        public static async Task<bool> TryInstallPip(bool force = false)
+        public static async Task<bool> TryInstallPip(Action<float> progress = null, CancellationToken token = default, bool force = false)
         {
             if (!IsPipInstalled() || force)
             {
                 try
                 {
-                    await InstallPip().ConfigureAwait(false);
+                    await InstallPip(progress, token).ConfigureAwait(false);
                 }
                 catch
                 {
@@ -377,67 +378,71 @@ namespace Python.Deployment
             return Directory.Exists(moduleDir) && File.Exists(Path.Combine(moduleDir, "__init__.py"));
         }
 
-        public static async Task RunCommand(string command, CancellationToken token)
+        public static async Task RunCommand(string command, CancellationToken token, Action<float> progress = null)
         {
             Process process = new Process();
             try
             {
-                string args = null;
-                string filename = null;
-                ProcessStartInfo startInfo = new ProcessStartInfo();
+                string filename, args;
+
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    // Unix/Linux/macOS specific command execution
                     filename = "/bin/bash";
-                    args = $"-c \"{command} \"";
+                    args = $"-c \"{command}\"";
                 }
                 else
                 {
-                    // Windows specific command execution
                     filename = "cmd.exe";
                     args = $"/C \"{command}\"";
                 }
+
                 Log($"> {filename} {args}");
-                startInfo = new ProcessStartInfo
+
+                var startInfo = new ProcessStartInfo
                 {
                     FileName = filename,
                     WorkingDirectory = EmbeddedPythonHome,
                     Arguments = args,
-
-                    // If the UseShellExecute property is true, the CreateNoWindow property value is ignored and a new window is created.
-                    // .NET Core does not support creating windows directly on Unix/Linux/macOS and the property is ignored.
-
                     CreateNoWindow = true,
-                    UseShellExecute = false, // necessary for stdout redirection
+                    UseShellExecute = false,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     WindowStyle = ProcessWindowStyle.Hidden,
                 };
+
                 process.StartInfo = startInfo;
                 process.Start();
-                // Note: see https://github.com/henon/Python.Included/issues/55#issuecomment-1634750418
-                // as to why the following lines are commented out
-                //process.BeginOutputReadLine();
-                //process.BeginErrorReadLine();
+
                 token.Register(() =>
                 {
-                    try
-                    {
-                        if (!process.HasExited)
-                            process.Kill();
-                    }
+                    try { if (!process.HasExited) process.Kill(); }
                     catch (Exception) { /* ignore */ }
                 });
-                // The documentation for Process.StandardOutput says to read before you wait otherwise you can deadlock!
-                string output = process.StandardOutput.ReadToEnd();
-                Log(output);
-                await Task.Run(() => { process.WaitForExit(); }, token).ConfigureAwait(false);
-                if (process.ExitCode != 0)
+
+                var readStdOut = ReadStreamAsync(process.StandardOutput, line =>
                 {
-                    Log(process.StandardError.ReadToEnd());
-                    Log(" => exit code " + process.ExitCode);
-                }
+                    Log(line);
+                    ParsePipProgress(line, progress);
+                }, token);
+
+                var readStdErr = ReadStreamAsync(process.StandardError, line =>
+                {
+                    Log(line);
+                    Console.WriteLine(line);
+                }, token);
+
+                await Task.WhenAll(readStdOut, readStdErr).ConfigureAwait(false);
+                await Task.Run(() => process.WaitForExit(), token).ConfigureAwait(false);
+
+                if (process.ExitCode == 0)
+                    progress?.Invoke(100.0f);
+
+                Log(" => exit code " + process.ExitCode);
+            }
+            catch (OperationCanceledException)
+            {
+                Log("RunCommand: 已取消");
             }
             catch (Exception e)
             {
@@ -449,6 +454,54 @@ namespace Python.Deployment
             }
         }
 
+        private static async Task ReadStreamAsync(
+            StreamReader reader,
+            Action<string> onLine,
+            CancellationToken token)
+        {
+            string line;
+            while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)
+            {
+                token.ThrowIfCancellationRequested();
+                onLine?.Invoke(line);
+            }
+        }
+
+        private static void ParsePipProgress(string line, Action<float> progress)
+        {
+            if (progress == null) return;
+            Console.WriteLine(line);
+            // pip 新版 (≥22.0): "  6.4/15.9 MB  1.2 MB/s"
+            var newPip = Regex.Match(line, @"([\d.]+)/([\d.]+)\s*(KB|MB|GB)");
+            if (newPip.Success)
+            {
+                if (float.TryParse(newPip.Groups[1].Value, out float current) &&
+                    float.TryParse(newPip.Groups[2].Value, out float total) &&
+                    total > 0)
+                {
+                    progress.Invoke(Math.Min(current / total * 100.0f, 100.0f));
+                    return;
+                }
+            }
+
+            // pip 旧版 (<22.0): "  |████████░░░░|"
+            var oldPip = Regex.Match(line, @"\|(█+)(░*)\|");
+            if (oldPip.Success)
+            {
+                int filled = oldPip.Groups[1].Value.Length;
+                int empty = oldPip.Groups[2].Value.Length;
+                int total = filled + empty;
+                if (total > 0)
+                {
+                    progress.Invoke((float)filled / total);
+                    return;
+                }
+            }
+
+            // 开始下载时重置为 0
+            if (Regex.IsMatch(line, @"Downloading .+\.whl"))
+                progress.Invoke(0.0f);
+        }
         private static bool AreAllFilesAlreadyPresent(ZipArchive zip, string lib)
         {
             var allFilesAllReadyPresent = true;

--- a/Python.Deployment/Installer.cs
+++ b/Python.Deployment/Installer.cs
@@ -302,7 +302,7 @@ namespace Python.Deployment
             if (version.Length > 0)
                 version = $"=={version}";
 
-            await RunCommand($"python -u -m \"{pipPath}\" install \"{module_name}{version}\" --no-cache-dir --progress-bar on {forceInstall}", token, progress).ConfigureAwait(false);
+            await RunCommand($"\"{pipPath}\" install \"{module_name}{version}\" {forceInstall}", token, progress).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Python.Included/Installer.cs
+++ b/Python.Included/Installer.cs
@@ -61,7 +61,7 @@ namespace Python.Included
             LogMessage?.Invoke(message);
         }
 
-        public static async Task SetupPython(bool force = false)
+        public static async Task SetupPython(Action<float> progress = null, CancellationToken token = default, bool force = false)
         {
             if (!PythonEnv.DeployEmbeddedPython)
                 return;
@@ -75,7 +75,7 @@ namespace Python.Included
                 Python.Deployment.Installer.Source = GetInstallationSource();
                 Python.Deployment.Installer.PythonDirectoryName = InstallDirectory;
                 Python.Deployment.Installer.InstallPath = InstallPath;
-                await Python.Deployment.Installer.SetupPython(force).ConfigureAwait(false);
+                await Python.Deployment.Installer.SetupPython(progress, token, force).ConfigureAwait(false);
             }
             finally
             {
@@ -149,7 +149,7 @@ namespace Python.Included
         /// </summary>
         /// <param name="module_name">The module/package to install </param>
         /// <param name="force">When true, reinstall the packages even if it is already up-to-date.</param>
-        public static async Task PipInstallModule(string module_name, string version = "", bool force = false, CancellationToken token = default)
+        public static async Task PipInstallModule(string module_name, string version = "", bool force = false, Action<float> progress = null, CancellationToken token = default)
         {
             try
             {
@@ -157,7 +157,7 @@ namespace Python.Included
                 Python.Deployment.Installer.Source = GetInstallationSource();
                 Python.Deployment.Installer.PythonDirectoryName = InstallDirectory;
                 Python.Deployment.Installer.InstallPath = InstallPath;
-                await Python.Deployment.Installer.PipInstallModule(module_name, version, force, token).ConfigureAwait(false);
+                await Python.Deployment.Installer.PipInstallModule(module_name, version, force, progress, token).ConfigureAwait(false);
             }
             finally
             {
@@ -171,7 +171,7 @@ namespace Python.Included
         /// <remarks>
         /// Creates the lib folder under <see cref="EmbeddedPythonHome"/> if it does not exist.
         /// </remarks>
-        public static async Task InstallPip(CancellationToken token = default)
+        public static async Task InstallPip(Action<float> progress = null, CancellationToken token = default)
         {
             try
             {
@@ -179,7 +179,7 @@ namespace Python.Included
                 Python.Deployment.Installer.Source = GetInstallationSource();
                 Python.Deployment.Installer.PythonDirectoryName = InstallDirectory;
                 Python.Deployment.Installer.InstallPath = InstallPath;
-                await Python.Deployment.Installer.InstallPip(token).ConfigureAwait(false);
+                await Python.Deployment.Installer.InstallPip(progress, token).ConfigureAwait(false);
             }
             finally
             {
@@ -187,13 +187,13 @@ namespace Python.Included
             }
         }
 
-        public static async Task<bool> TryInstallPip(bool force = false)
+        public static async Task<bool> TryInstallPip(Action<float> progress = null, CancellationToken token = default, bool force = false)
         {
             if (!IsPipInstalled() || force)
             {
                 try
                 {
-                    await InstallPip().ConfigureAwait(false);
+                    await InstallPip(progress, token).ConfigureAwait(false);
                 }
                 catch
                 {


### PR DESCRIPTION
1. Expose the progress callback of Downloader.Download step by step to external interfaces.
2. Add an Action<float> progress parameter to RunCommand, and also add an Action<float> progress parameter to PipInstallModule, which calls it.

Purpose: When calling functions like await Installer.TryInstallPip(); and await Installer.PipInstallModule("torch", progress: progress); sometimes, due to network issues or very large packages, the program has to wait a long time without any progress feedback. Simply showing a loading spinner isn’t ideal, so here we add a progress callback parameter to make it easier to display the current progress in real time.

PS: The code was implemented using AI, and self-testing shows no issues so far. Here's my test code—you can also try it out to see if it works. If there are no problems, it can be merged and published to NuGet (pre-release is fine too). I'm a bit pressed to use it. Thanks a lot!

```c#
using Python.Included;

namespace PythonDemo
{
    internal class Program
    {
        static async Task Main(string[] args)
        {
            Installer.LogMessage += Installer_LogMessage;
            //Console.WriteLine("Hello, World!");
            await Installer.SetupPython();
            await Installer.TryInstallPip();
            Action<float> progress = p =>
            {
                Console.WriteLine(p);
            };
            await Installer.PipInstallModule("torch", progress: progress);
        }

        private static void Installer_LogMessage(string obj)
        {
            Console.WriteLine(obj);
        }
    }
}
```